### PR TITLE
Fix namespacing of context vars

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,8 +6,8 @@
     "author_name": "Your Name",
     "email": "Your email",
     "description": "A short description of the project.",
-    "heroku_app_name": "{{ repo_name }}",
-    "domain_name": "{{ heroku_app_name }}.herokuapp.com",
+    "heroku_app_name": "{{ cookiecutter.repo_name }}",
+    "domain_name": "{{ cookiecutter.heroku_app_name }}.herokuapp.com",
     "version": "0.1.0",
     "now": "2015/01/13",
     "year": "{{ cookiecutter.now[:4] }}"

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -33,7 +33,7 @@ migrate_production:
 
 collectstatic_production:
 	./manage.py collectstatic --noinput
-	aws s3 sync {{ cookiecutter.repo_name }}/static s3://{{ aws_s3_bucket_name }}/static/
+	aws s3 sync {{ cookiecutter.repo_name }}/static s3://{{ cookiecutter.aws_s3_bucket_name }}/static/
 
 # shortcuts for deploy to the production
 dp: deploy_production


### PR DESCRIPTION
When I tried out the template, I got this error:

```
cookiecutter https://github.com/dulaccc/cookiecutter-django-herokuapp
You've cloned /Users/audreyr/.cookiecutters/cookiecutter-django-herokuapp before. Is it okay to delete and re-clone it? [yes]: 
Cloning into 'cookiecutter-django-herokuapp'...
remote: Counting objects: 348, done.
remote: Total 348 (delta 0), reused 0 (delta 0), pack-reused 348
Receiving objects: 100% (348/348), 57.12 KiB | 0 bytes/s, done.
Resolving deltas: 100% (189/189), done.
Checking connectivity... done.
project_name [project_name is the title of the project.]: myproj2 
repo_name [myproj2]: 
aws_s3_user_name [heroku-myproj2]: 
aws_s3_bucket_name [myproj2]: 
author_name [Your Name]: 
email [audreyr@gmail.com]: 
description [A short description of the project.]: 
Unable to render variable 'heroku_app_name'
Error message: 'repo_name' is undefined
Context: {
    "cookiecutter": {
        "author_name": "Your Name",
        "aws_s3_bucket_name": "{{ cookiecutter.repo_name }}",
        "aws_s3_user_name": "heroku-{{ cookiecutter.repo_name }}",
        "description": "A short description of the project.",
        "domain_name": "{{ heroku_app_name }}.herokuapp.com",
        "email": "audreyr@gmail.com",
        "heroku_app_name": "{{ repo_name }}",
        "now": "2015/01/13",
        "project_name": "project_name is the title of the project.",
        "repo_name": "{{ cookiecutter.project_name.lower()|replace(' ', '_') }}",
        "version": "0.1.0",
        "year": "{{ cookiecutter.now[:4] }}"
    }
}
```

And when I fixed it, I got this similarly:

```
Unable to create file 'Makefile'
Error message: 'aws_s3_bucket_name' is undefined
Context: {
    "cookiecutter": {
        "author_name": "Your Name",
        "aws_s3_bucket_name": "myproj3",
        "aws_s3_user_name": "heroku-myproj3",
        "description": "A short description of the project.",
        "domain_name": "myproj3.herokuapp.com",
        "email": "audreyr@gmail.com",
        "heroku_app_name": "myproj3",
        "now": "2015/01/13",
        "project_name": "myproj3",
        "repo_name": "myproj3",
        "version": "0.1.0",
        "year": "2015"
    }
}
```

This PR fixes the above errors by namespacing the default values and the context var used in the Makefile.

To try it out, run the following:

```
cookiecutter https://github.com/audreyr/cookiecutter-django-herokuapp -c fix-default-value-namespacing
```

(I typed in `myproj` for the project_name, then left the rest blank.)
